### PR TITLE
Accept new bills after rejecting.

### DIFF
--- a/scripts/fnordload
+++ b/scripts/fnordload
@@ -361,6 +361,7 @@ class Fnordload(object):
         except fnordload.InvalidNoteError:
             self._lcd.rejected_note()
             time.sleep(2)
+            self._give_change()
         except fnordload.TimeoutError:
             pass
 


### PR DESCRIPTION
Einige Banknoten will der Scheinprüfer einfach nicht beim ersten akzeptieren - dann immer mit "1" wieder ins Wechselmenü zu gehen ist etwas nervig...

Ich habe das Mal provisorisch im Fnordload so eingeschaltet. Sollen wir das dauerhaft so mergen?

Eventuell dann auch für das uPay-Modul?
